### PR TITLE
Declare runtime deps and split optional extras in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,22 @@ dependencies = [
     "numpy>2.0.0",
     "scipy",
     "numba",
-    "pytest",
-    "h5py"
+    "h5py",
+    "WDMWaveletTransforms",
 ]
 requires-python = ">=3.12"
+
+[project.optional-dependencies]
+# Development / test tooling.
+dev = ["pytest"]
+# COSMIC compatibility mode: loading/processing COSMIC population HDF5 catalogs
+# (see GalacticStochastic/cosmic_data_helpers.py, imported behind an optional guard).
+cosmic = ["pandas", "astropy"]
+# Plotting / figure-generation scripts (make_gb_*_compare_plot.py, plot_creation_helpers.py).
+plots = ["matplotlib"]
+# PyIMRPhenomD is not yet published on PyPI, so it is kept optional for now.
+# Install it from its own source, or via: pip install ".[imrphenomd]" once available.
+imrphenomd = ["PyIMRPhenomD"]
 
 
 [build-system]


### PR DESCRIPTION
## Summary

Aligns `pyproject.toml` with what the code actually imports, and organizes non-core packages into optional-dependency extras so `pip install .` pulls only what the library needs at runtime.

Several packages were imported across the repo but not declared (`matplotlib`, `astropy`, `pandas`, `WDMWaveletTransforms`, `PyIMRPhenomD`). Rather than dumping them all into core dependencies, they're grouped by how they're used.

## Dependency layout

| Group | Packages | Notes |
|-------|----------|-------|
| core `dependencies` | numpy, scipy, numba, h5py, WDMWaveletTransforms | needed to import/run the library |
| `dev` | pytest | test tooling |
| `cosmic` | pandas, astropy | COSMIC compatibility mode only; imported behind an `ImportError` guard in `global_file_index.py` via `cosmic_data_helpers.py` |
| `plots` | matplotlib | figure-generation scripts (`make_gb_*_compare_plot.py`, `plot_creation_helpers.py`) |
| `imrphenomd` | PyIMRPhenomD | **not published on PyPI**; install from its own source for now |

## Notes

- `pandas`/`astropy` were verified to be imported **only** in `GalacticStochastic/cosmic_data_helpers.py`, which is loaded behind a `try/except ImportError` (`PANDAS_AVAILABLE` flag) — so the core path degrades gracefully without them.
- `PyIMRPhenomD` is required by the IMRPhenomD waveform code but is not on PyPI, so it is kept as an optional extra until it is published; the install URL can be wired up later.
- Install combos: `pip install ".[dev]"`, `".[cosmic,plots]"`, or `".[dev,cosmic,plots,imrphenomd]"` for everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)