### PR TITLE
Add CI workflows (build, lint, type-check) using uv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    # mypy has its own dedicated type-check workflow, so it is skipped here to
+    # avoid running it twice. Drop this `SKIP` to run every hook in this job.
+    env:
+      SKIP: mypy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Run pre-commit hooks
+        run: uvx pre-commit run --all-files --show-diff-on-failure --color=always

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,36 @@
+name: Type Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: typecheck-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+  # Keep in sync with the mypy rev in .pre-commit-config.yaml
+  MYPY_VERSION: "1.18.2"
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Run mypy
+        run: >
+          uvx --from "mypy==${{ env.MYPY_VERSION }}" mypy
+          --ignore-missing-imports
+          --explicit-package-bases
+          .


### PR DESCRIPTION
## Summary

Adds three GitHub Actions workflows under `.github/workflows/`, each using [`uv`](https://docs.astral.sh/uv/) (`astral-sh/setup-uv`) with install caching for speed. There were no workflows before this.

| Workflow | Job | Runs |
|----------|-----|------|
| `build.yml` | Build | `uv build` (sdist + wheel) → `twine check` → uploads `dist/` artifact |
| `lint.yml` | Lint | `pre-commit run --all-files` (all hooks), with `~/.cache/pre-commit` cached |
| `typecheck.yml` | Type Check | `mypy --ignore-missing-imports` over the repo |

## Design notes

- **uv + caching everywhere** — `astral-sh/setup-uv@v6` with `enable-cache: true` and `cache-dependency-glob: "**/pyproject.toml"`; tools run via `uvx` so there's no separate install step. `lint.yml` additionally caches the pre-commit hook environments keyed on `.pre-commit-config.yaml`.
- **No runtime deps installed** — build uses build isolation (only setuptools/wheel); lint and type-check use `--ignore-missing-imports`. This keeps the jobs fast and avoids depending on PyPI wheel availability for `numba`/`PyIMRPhenomD`/etc.
- **mypy de-duplication** — pre-commit also defines a mypy hook, so `lint.yml` sets `SKIP: mypy` and mypy runs only in the dedicated `typecheck.yml`. The mypy version there (1.18.2) is pinned to match the pre-commit hook, with a comment to keep them in sync.
- **Python 3.12** (the `requires-python` floor) is set via a `PYTHON_VERSION` env at the top of each file for easy editing; can be bumped to 3.14 or expanded to a matrix later.
- Each workflow triggers on push-to-`main`, pull requests, and manual dispatch, with `concurrency` cancellation of superseded runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)