### PR TITLE
Migrate pre-commit type-check hook to pyrefly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,8 @@ env:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    # mypy has its own dedicated type-check workflow, so it is skipped here to
-    # avoid running it twice. Drop this `SKIP` to run every hook in this job.
-    env:
-      SKIP: mypy
+    # Runs every pre-commit hook, including pyrefly type checking. mypy is not a
+    # pre-commit hook anymore; it runs in the dedicated typecheck.yml workflow.
     steps:
       - uses: actions/checkout@v4
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,10 @@ repos:
   - id: ruff
     args: [--preview, --fix]
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.18.2
+- repo: https://github.com/facebook/pyrefly-pre-commit
+  rev: 1.1.1
   hooks:
-  - id: mypy
-    args: [--ignore-missing-imports]
+  - id: pyrefly-check
+    # Behavior (e.g. ignore-missing-imports for uninstalled deps) is configured
+    # under [tool.pyrefly] in pyproject.toml. The dedicated type-check CI
+    # (.github/workflows/typecheck.yml) still runs mypy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,22 @@ include = ["GalacticStochastic*", "LisaWaveformTools*", "WaveletWaveforms*"]
 
 [project.scripts]
 run-galactic-stochastic-iterative = "GalacticStochastic.cli.run_iterative_procedure:main"
+
+[tool.pyrefly]
+# Used by the pyrefly-check pre-commit hook. The hook environment does not
+# install the project's runtime deps, so treat them as Any when unresolved --
+# this preserves the behavior of the old mypy hook's --ignore-missing-imports.
+# (The standalone type-check CI still runs mypy.)
+python-version = "3.12"
+ignore-missing-imports = [
+    "numpy", "numpy.*",
+    "scipy", "scipy.*",
+    "numba", "numba.*",
+    "h5py", "h5py.*",
+    "astropy", "astropy.*",
+    "pandas", "pandas.*",
+    "matplotlib", "matplotlib.*",
+    "pytest", "pytest.*",
+    "PyIMRPhenomD", "PyIMRPhenomD.*",
+    "WDMWaveletTransforms", "WDMWaveletTransforms.*",
+]


### PR DESCRIPTION
## Summary

**Stacked on top of #27** (base branch is `ci/github-actions-workflows`, not `main`).

Swaps the **mypy pre-commit hook** for [pyrefly](https://pyrefly.org/). Per request, the dedicated type-check CI (`typecheck.yml`) is left **unchanged on mypy** — so this migrates only the pre-commit hook, giving pyrefly (pre-commit) and mypy (CI) side by side.

## Changes

- **`.pre-commit-config.yaml`** — replace `pre-commit/mirrors-mypy@v1.18.2` with the official `facebook/pyrefly-pre-commit@1.1.1` (`pyrefly-check` hook).
- **`pyproject.toml`** — add `[tool.pyrefly]`:
  - `ignore-missing-imports` for the project's third-party deps (numpy, scipy, numba, h5py, astropy, pandas, matplotlib, pytest, PyIMRPhenomD, WDMWaveletTransforms). The pre-commit hook environment installs none of these, so this preserves the old hook's `--ignore-missing-imports` behavior.
  - `python-version = "3.12"` to match `requires-python` and the CI Python version.
- **`.github/workflows/lint.yml`** — drop the now-stale `SKIP: mypy` env (there's no mypy hook to skip anymore). The pre-commit job runs pyrefly; mypy continues to run in `typecheck.yml`.

## Notes

- The official hook uses `language: python`, so pre-commit installs pyrefly itself — no extra setup needed.
- CI failures are still being deferred (see #27); this PR doesn't attempt to fix the pre-existing type/lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)