### PR TITLE
Migrate lint CI from pre-commit to prek

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,11 @@ env:
   PYTHON_VERSION: "3.12"
 
 jobs:
-  pre-commit:
+  prek:
     runs-on: ubuntu-latest
-    # Runs every pre-commit hook, including pyrefly type checking. mypy is not a
-    # pre-commit hook anymore; it runs in the dedicated typecheck.yml workflow.
+    # prek is a drop-in replacement for pre-commit and reads the same
+    # .pre-commit-config.yaml. Runs every hook, including pyrefly type checking;
+    # mypy is not a hook anymore, it runs in the dedicated typecheck.yml workflow.
     steps:
       - uses: actions/checkout@v4
 
@@ -28,13 +29,13 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache-dependency-glob: "**/pyproject.toml"
 
-      - name: Cache pre-commit hook environments
+      - name: Cache prek hook environments
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: prek-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
-            pre-commit-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+            prek-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
 
-      - name: Run pre-commit hooks
-        run: uvx pre-commit run --all-files --show-diff-on-failure --color=always
+      - name: Run prek hooks
+        run: uvx prek run --all-files --show-diff-on-failure --color=always


### PR DESCRIPTION
## Summary

**Stacked on top of #28** (base branch is `ci/pre-commit-pyrefly`).

Migrates the lint workflow from [pre-commit](https://pre-commit.com/) to [prek](https://github.com/j178/prek) — a fast, Rust-based, dependency-free **drop-in replacement** that reads the exact same `.pre-commit-config.yaml`. Because it's drop-in, the config file is untouched; only the CI invocation changes.

## Changes (`.github/workflows/lint.yml` only)

- Run `uvx prek run --all-files --show-diff-on-failure --color=always` instead of the `pre-commit` equivalent. All three flags are verified-supported by `prek run` (per prek's CLI reference).
- Cache `~/.cache/prek` instead of `~/.cache/pre-commit` (prek's cache location), with the key prefix updated to `prek-`.
- Rename the job `pre-commit` → `prek`.

## Notes

- `.pre-commit-config.yaml` is **unchanged** — prek consumes it as-is, which is the whole point of the drop-in design.
- Still installed/run via `uvx`, consistent with the other workflows; prek manages hook environments with uv under the hood, so this also speeds up the lint job.
- CI failures remain deferred (see #27); this PR doesn't address the pre-existing ruff/type findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)