### PR TITLE
Expand pre-commit hooks, modernize versions, add actionlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -24,20 +24,29 @@ repos:
   - id: pretty-format-json
     args: [--autofix]
   - id: requirements-txt-fixer
+  # Additional regression guards (verified to pass on the current tree)
+  - id: check-merge-conflict
+  - id: check-builtin-literals
+  - id: check-illegal-windows-names
+  - id: check-shebang-scripts-are-executable
+  - id: destroyed-symlinks
+  - id: forbid-submodules
+  - id: fix-byte-order-marker
+  - id: double-quote-string-fixer
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.19.1
+  rev: v3.21.2
   hooks:
   - id: pyupgrade
     args: [--keep-percent-format]
 
 - repo: https://github.com/bwhmather/ssort
-  rev: 0.14.0
+  rev: 0.16.0
   hooks:
   - id: ssort
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.8
+  rev: v0.15.18
   hooks:
   - id: ruff
     args: [--preview, --fix]
@@ -49,3 +58,8 @@ repos:
     # Behavior (e.g. ignore-missing-imports for uninstalled deps) is configured
     # under [tool.pyrefly] in pyproject.toml. The dedicated type-check CI
     # (.github/workflows/typecheck.yml) still runs mypy.
+
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.12
+  hooks:
+  - id: actionlint


### PR DESCRIPTION
## Summary

**Stacked on top of #29** (base branch is `ci/prek-migration`).

Modernizes the pinned hook versions, adds the standard `pre-commit-hooks` that pass on the current tree, and adds an **actionlint** hook for the GitHub Actions workflows. Each addition was verified with `prek run --all-files` before inclusion.

## Version bumps (modernize)

| Repo | Old | New |
|------|-----|-----|
| `pre-commit/pre-commit-hooks` | v3.2.0 | **v6.0.0** |
| `asottile/pyupgrade` | v3.19.1 | **v3.21.2** |
| `bwhmather/ssort` | 0.14.0 | **0.16.0** |
| `astral-sh/ruff-pre-commit` | v0.11.8 | **v0.15.18** |
| `facebook/pyrefly-pre-commit` | 1.1.1 | 1.1.1 (already latest) |

pyupgrade and ssort still pass cleanly after the bump (no new rewrites).

## New hooks added (all pass now)

From `pre-commit/pre-commit-hooks`:
- `check-merge-conflict` — catches committed conflict markers
- `destroyed-symlinks` — complements the existing `check-symlinks`
- `check-shebang-scripts-are-executable`
- `fix-byte-order-marker` — no BOMs currently
- `check-illegal-windows-names` — cross-platform filename guard
- `forbid-submodules` — no submodules
- `check-builtin-literals`
- `double-quote-string-fixer` — the codebase is already single-quoted

New repo:
- `rhysd/actionlint` **v1.7.12** (`actionlint` hook) — passes on all three workflows. prek auto-installs the Go toolchain to build it, so no extra CI step is needed.

## Deliberately not added (currently fail — need a prep change)

- `check-executables-have-shebangs` — 7 library `.py` files carry the executable bit without a shebang (accidental). Would need `git update-index --chmod=-x` on those files first.
- `name-tests-test` — the repo uses pytest's `test_*.py`; this hook defaults to `*_test.py` and would also flag the `generate_raantenna_test_outputs.py` helper.

## Notes

- ruff was already failing pre-existing lint (deferred per #27); bumping it to v0.15.18 keeps that deferred — this PR doesn't attempt those fixes.
- `double-quote-string-fixer` passes today; note it would conflict with `ruff format` (double-quote default) if that's ever adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)