### PR TITLE
Restore pyproject dependency/extras work (re-merge #26)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,22 @@ dependencies = [
     "numpy>2.0.0",
     "scipy",
     "numba",
-    "pytest",
-    "h5py"
+    "h5py",
+    "WDMWaveletTransforms",
 ]
 requires-python = ">=3.12"
+
+[project.optional-dependencies]
+# Development / test tooling.
+dev = ["pytest"]
+# COSMIC compatibility mode: loading/processing COSMIC population HDF5 catalogs
+# (see GalacticStochastic/cosmic_data_helpers.py, imported behind an optional guard).
+cosmic = ["pandas", "astropy"]
+# Plotting / figure-generation scripts (make_gb_*_compare_plot.py, plot_creation_helpers.py).
+plots = ["matplotlib"]
+# PyIMRPhenomD is not yet published on PyPI, so it is kept optional for now.
+# Install it from its own source, or via: pip install ".[imrphenomd]" once available.
+imrphenomd = ["PyIMRPhenomD"]
 
 
 [build-system]


### PR DESCRIPTION
## Summary

Re-applies the pyproject.toml work from #26, which was merged into `main` (as `fe95f9e`) but then dropped when `main` was force-pushed to `5e34dd1`. GitHub does not allow reopening a merged PR, so this is a fresh PR that cherry-picks the original commit (`8cf42d9`) back on top of the current `main`.

The change is byte-identical to what #26 merged:

- core `dependencies`: declare `WDMWaveletTransforms`, drop `pytest` from core
- `[project.optional-dependencies]`: `dev` (pytest), `cosmic` (pandas, astropy), `plots` (matplotlib), `imrphenomd` (PyIMRPhenomD)

## Why it's safe

- The new `main` commit `5e34dd1` only touched source files (`LisaWaveformTools/*`, `WaveletWaveforms/chirplet_funcs.py`), not `pyproject.toml`, so the cherry-pick applied with no conflicts.
- Diff is `pyproject.toml` only (+14/-2).

## Note on the open CI stack

The stacked CI PRs (#27–#31) were branched off the *old* main that still contained this work, so they currently carry it in their base. Once this PR merges, rebasing that stack onto the updated `main` will make the duplicated pyproject commit a no-op (git drops it), leaving the stack clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)