### PR TITLE
Add docstring-linting CI (pydoclint, numpy) scoped to darglint's rules

### DIFF
--- a/.github/workflows/docstrings.yml
+++ b/.github/workflows/docstrings.yml
@@ -1,0 +1,36 @@
+name: Docstrings
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: docstrings-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+  # Keep in sync with the pydoclint version used locally.
+  PYDOCLINT_VERSION: "0.8.7"
+
+jobs:
+  pydoclint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache-dependency-glob: "**/pyproject.toml"
+
+      # numpy-style docstring/signature linting. Options come from
+      # [tool.pydoclint] in pyproject.toml (scoped to roughly the darglint rules).
+      - name: Run pydoclint
+        run: >
+          uvx "pydoclint@${{ env.PYDOCLINT_VERSION }}"
+          GalacticStochastic LisaWaveformTools WaveletWaveforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,19 @@ ignore-missing-imports = [
     "PyIMRPhenomD", "PyIMRPhenomD.*",
     "WDMWaveletTransforms", "WDMWaveletTransforms.*",
 ]
+
+[tool.pydoclint]
+# Docstring-signature linting (the maintained successor to the now-archived
+# darglint). These options scope pydoclint to roughly the same rules darglint
+# enforced -- argument, return-presence, and raises consistency for numpy-style
+# docstrings -- by disabling the checks darglint does not perform:
+#   check-return-types  -> off : darglint does not check return types (DOC203)
+#   check-class-attributes -> off : darglint does not check class attrs (DOC60x)
+#   allow-init-docstring -> on : darglint documents __init__ args in __init__,
+#                                not the class docstring (DOC301)
+# The stricter-than-darglint DOC105 (arg type-hint matching) and DOC503 (raises
+# vs. `assert`) findings are intentionally left enabled.
+style = "numpy"
+check-return-types = false
+check-class-attributes = false
+allow-init-docstring = true


### PR DESCRIPTION
## Summary

Adds a dedicated **Docstrings** CI workflow that lints numpy-style docstrings with [pydoclint](https://github.com/jsh9/pydoclint) — the actively-maintained successor to the now-archived **darglint** — configured to roughly mirror the rules darglint enforced.

## Why pydoclint (not pydocstyle)

- **darglint** checks docstring-vs-**signature consistency** (params / returns / raises documented). It's archived, so we shouldn't depend on it.
- **pydocstyle** (ruff `D` rules, already partially enabled) checks docstring **style** — a different axis.
- **pydoclint** is the maintained drop-in for darglint's job.

## Config — mirroring darglint's scope

pydoclint at defaults raised ~117 findings; many are checks darglint never did. `[tool.pydoclint]` disables those so it lands on darglint's rule set:

```toml
[tool.pydoclint]
style = "numpy"
check-return-types = false       # darglint doesn't check return types  (drops DOC203)
check-class-attributes = false   # darglint doesn't check class attrs    (drops DOC60x)
allow-init-docstring = true       # __init__ args documented in __init__  (drops DOC301)
```

This removes the out-of-scope categories (return-type, class-attribute, and `__init__`-structure checks) — ~42 findings — leaving the argument / return-presence / raises checks that are darglint's domain.

Per request, the two stricter-than-darglint buckets are **left enabled**: `DOC105` (argument type-hint matching) and `DOC503` (raises vs. bare `assert`).

## Workflow

`.github/workflows/docstrings.yml` runs `uvx pydoclint` over the source packages (`GalacticStochastic`, `LisaWaveformTools`, `WaveletWaveforms`), reading the config from `pyproject.toml` — same uv + caching pattern as the build/lint/typecheck workflows.

## Current state

The workflow currently reports **75 findings** (DOC101/103 missing-or-mismatched args, DOC501/502 raises, plus the left-in DOC105/DOC503). These are the darglint-equivalent cleanups and are expected to fail for now, consistent with the other in-progress CI checks — no docstrings were changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)