### PR TITLE
Fix all 75 pydoclint violations (docstrings only)

### DIFF
--- a/GalacticStochastic/background_decomposition.py
+++ b/GalacticStochastic/background_decomposition.py
@@ -54,8 +54,6 @@ def _check_correct_component_shape(
 
     Raises
     ------
-    AssertionError
-        If the input array does not have the expected size or an allowed shape.
     ValueError
         If an invalid `shape_mode` is provided.
     """
@@ -103,16 +101,16 @@ class BGDecomposition:
             Wavelet constants describing the time-frequency grid.
         nc_galaxy : int
             Number of tdi channels in the galactic background.
-        galactic_floor : ndarray of float, optional
+        galactic_floor : NDArray[np.floating] | None, optional
             Array containing the faintest (floor) component of the galactic background.
             If None, initialized to zeros.
-        galactic_below : ndarray of float, optional
+        galactic_below : NDArray[np.floating] | None, optional
             Array containing the faint component of the galactic background.
             If None, initialized to zeros.
-        galactic_undecided : ndarray of float, optional
+        galactic_undecided : NDArray[np.floating] | None, optional
             Array containing the undecided component of the galactic background.
             If None, initialized to zeros.
-        galactic_above : ndarray of float, optional
+        galactic_above : NDArray[np.floating] | None, optional
             Array containing the bright (above threshold) component of the galactic background.
             If None, initialized to zeros.
         track_mode : int
@@ -127,8 +125,6 @@ class BGDecomposition:
         ------
         ValueError
             If an unrecognized storage mode is provided.
-        AssertionError
-            If provided arrays do not match the expected shapes.
         """
         if storage_mode not in (0, 1):
             msg = 'Unrecognized option for storage mode'
@@ -761,7 +757,7 @@ class BGDecomposition:
             Smoothing length in the frequency domain.
         filter_periods : int
             Number of periods to use for filtering.
-        period_list : tuple of int or float
+        period_list : tuple[int, ...] | tuple[np.floating, ...]
             List of periods to consider in the cyclostationary analysis.
 
         Returns
@@ -802,7 +798,7 @@ class BGDecomposition:
             Smoothing length in the frequency domain.
         filter_periods : int
             Number of periods to use for filtering.
-        period_list : tuple of int or float
+        period_list : tuple[int, ...] | tuple[np.floating, ...]
             List of periods to consider in the cyclostationary analysis.
 
         Returns

--- a/GalacticStochastic/config_helper.py
+++ b/GalacticStochastic/config_helper.py
@@ -73,7 +73,7 @@ def get_config_dict_from_file(toml_filename: str) -> dict[str, Any]:
     config : dict[str, Any]
         Dictionary containing configuration parameters loaded from the TOML file.
 
-"""
+    """
     with Path(toml_filename).open('rb') as f:
         config: dict[str, Any] = tomllib.load(f)
 

--- a/GalacticStochastic/config_helper.py
+++ b/GalacticStochastic/config_helper.py
@@ -38,11 +38,7 @@ def get_config_objects_from_dict(
     instrument_random_seed : int
         Random seed for instrument noise realization.
 
-    Raises
-    ------
-    AssertionError
-        If the number of galaxy channels exceeds the number of waveform or SNR channels.
-    """
+"""
     wc = get_wavelet_model(config)
 
     lc = get_lisa_constants(config)
@@ -77,11 +73,7 @@ def get_config_dict_from_file(toml_filename: str) -> dict[str, Any]:
     config : dict[str, Any]
         Dictionary containing configuration parameters loaded from the TOML file.
 
-    Raises
-    ------
-    AssertionError
-        If the toml filename exists in the dict but is different than expected
-    """
+"""
     with Path(toml_filename).open('rb') as f:
         config: dict[str, Any] = tomllib.load(f)
 

--- a/GalacticStochastic/config_helper.py
+++ b/GalacticStochastic/config_helper.py
@@ -38,7 +38,7 @@ def get_config_objects_from_dict(
     instrument_random_seed : int
         Random seed for instrument noise realization.
 
-"""
+    """
     wc = get_wavelet_model(config)
 
     lc = get_lisa_constants(config)

--- a/GalacticStochastic/cosmic_data_helpers.py
+++ b/GalacticStochastic/cosmic_data_helpers.py
@@ -150,8 +150,6 @@ def load_cosmic(filename: str, categories: list[str]) -> tuple[NDArray[np.floati
     ------
     ValueError
         if the categories are not as required
-    AssertionError
-        if the file format is incorrect
     """
     if categories != ['dgb']:
         msg = 'COSMIC data only supports dgb category'

--- a/GalacticStochastic/galactic_fit_helpers.py
+++ b/GalacticStochastic/galactic_fit_helpers.py
@@ -39,22 +39,22 @@ def S_gal_model_5param(
 
     Parameters
     ----------
-    f : float or NDArray[np.floating]
+    f : NDArray[np.floating] | float
         Frequency (Hz) at which to evaluate the model.
-    log10_a : float or NDArray[np.floating]
+    log10_a : NDArray[np.floating] | float
         Base-10 logarithm of the amplitude normalization.
-    log10_f2 : float or NDArray[np.floating]
+    log10_f2 : NDArray[np.floating] | float
         Base-10 logarithm of the frequency scale in Hz for the tanh transition.
-    log10_f1 : float or NDArray[np.floating]
+    log10_f1 : NDArray[np.floating] | float
         Base-10 logarithm of the exponential cutoff frequency in Hz
-    log10_fknee : float or NDArray[np.floating]
+    log10_fknee : NDArray[np.floating] | float
         Base-10 logarithm of the knee frequency in Hz for the tanh transition.
-    alpha : float or NDArray[np.floating]
+    alpha : NDArray[np.floating] | float
         Exponent controlling the sharpness of the exponential cutoff.
 
     Returns
     -------
-    S_gal : float or NDArray[np.floating]
+    S_gal : NDArray[np.floating] | float
         The modeled galactic binary confusion noise amplitude at the specified frequency.
     """
     return (
@@ -83,26 +83,26 @@ def S_gal_model_7param(
 
     Parameters
     ----------
-    f : float or NDArray[np.floating]
+    f : NDArray[np.floating] | float
         Frequency (Hz) at which to evaluate the model.
-    log10_a : float or NDArray[np.floating]
+    log10_a : NDArray[np.floating] | float
         Base-10 logarithm of the amplitude normalization.
-    log10_f2 : float or NDArray[np.floating]
+    log10_f2 : NDArray[np.floating] | float
         Base-10 logarithm of the frequency scale in Hz for the tanh transition.
-    log10_f1 : float | NDArray[np.floating]
+    log10_f1 : NDArray[np.floating] | float
         Base-10 logarithm of the exponential cutoff frequency in Hz, set to 0. in the referenced paper
-    log10_fknee : float or NDArray[np.floating]
+    log10_fknee : NDArray[np.floating] | float
         Base-10 logarithm of the knee frequency in Hz for the tanh transition.
-    alpha : float or NDArray[np.floating]
+    alpha : NDArray[np.floating] | float
         Exponent controlling the sharpness of the exponential cutoff.
-    beta : float or NDArray[np.floating]
+    beta : NDArray[np.floating] | float
         Scale parameter for the oscillatory part of the exponent, in Hz^-1
-    kappa : float or NDArray[np.floating]
+    kappa : NDArray[np.floating] | float
         1/f, argument for the oscillatory part of the exponent, in Hz^-1.
 
     Returns
     -------
-    S_gal : float or NDArray[np.floating]
+    S_gal : NDArray[np.floating] | float
         The modeled galactic binary confusion noise amplitude at the specified frequency.
 
     Note
@@ -136,7 +136,7 @@ def filter_periods_fft(
     ----------
     r_mean : NDArray[np.floating]
         Input time series to be filtered. Array of shape (Nt, n_channels), where Nt is the number of time samples.
-    period_list : tuple of int or float
+    period_list : tuple[int, ...] | tuple[float, ...] | tuple[np.floating, ...]
         Periods (in multiples of `t_obs/gc.SECSYEAR`) to retain in the filtered signal.
     nt_lim : PixelGenericRange
         Time range object defining the time sampling and limits of the input time series.
@@ -347,7 +347,7 @@ def get_S_cyclo(
         Smoothing length (standard deviation) in log-frequency space.
     filter_periods : int
         If nonzero, apply FFT-based filtering to restrict to specific periods.
-    period_list : tuple of int or float
+    period_list : tuple[int, ...] | tuple[np.floating, ...] | None
         Periods (in multiples of observation time in years) to retain in the filtered signal.
         If None and filtering is enabled, all possible periods are used.
     faint_cutoff_thresh : float

--- a/GalacticStochastic/global_file_index.py
+++ b/GalacticStochastic/global_file_index.py
@@ -42,7 +42,7 @@ def get_galaxy_filename(config: dict[str, Any]) -> str:
 
     Parameters
     ----------
-    config : dict of str to Any
+    config : dict[str, Any]
         Configuration dictionary containing file paths.
 
     Returns
@@ -61,7 +61,7 @@ def get_processed_galactic_filename(
 
     Parameters
     ----------
-    config : dict of str to Any
+    config : dict[str, Any]
         Configuration dictionary containing file paths.
     wc : WDMWaveletConstants
         Wavelet constants describing the time-frequency grid.
@@ -165,7 +165,7 @@ def get_full_galactic_params(config: dict[str, Any]) -> tuple[NDArray[np.floatin
 
     Parameters
     ----------
-    config : dict of str to Any
+    config : dict[str, Any]
         Configuration dictionary containing file paths, frequency limits, and component list.
 
     Returns
@@ -177,12 +177,8 @@ def get_full_galactic_params(config: dict[str, Any]) -> tuple[NDArray[np.floatin
 
     Raises
     ------
-    AssertionError
-        If parameter values are out of expected bounds or contain non-finite values.
     TypeError
         If the HDF5 file structure does not match the expected format.
-    UserWarning
-        If some parameters are always zero or have suspicious values (issued as warnings).
 
     Notes
     -----
@@ -283,13 +279,13 @@ def load_processed_galactic_file(
     ----------
     ifm : IterativeFitManager
         The manager object into which the loaded results will be stored.
-    config : dict of str to Any
+    config : dict[str, Any]
         Configuration dictionary containing file paths and iterative fit settings.
     ic : IterationConfig
         Configuration object specifying the parameters for the iterative fit.
     wc : WDMWaveletConstants
         Wavelet constants describing the time-frequency grid.
-    nt_lim_snr : tuple of int
+    nt_lim_snr : tuple[int, int]
         Tuple specifying the time-frequency pixel range to use. Defaults to (0, -1), which uses the full range.
     cyclo_mode : int
         Cyclostationary mode key used to select the correct HDF5 group (default is 1).
@@ -374,12 +370,15 @@ def store_processed_gb_file(
 
     Parameters
     ----------
-    config : dict of str to Any
+    config : dict[str, Any]
         Configuration dictionary containing file paths and iterative fit settings.
     wc : WDMWaveletConstants
         Wavelet constants describing the time-frequency grid.
     ifm : IterativeFitManager
         Manager object containing the results of the iterative fit to be stored.
+    params_gb_in : NDArray[np.floating]
+        Array of shape (n_binaries, n_par_gb) containing the galactic binary parameters;
+        used to compute a SHA256 checksum for provenance tracking.
     write_mode : int
         File writing mode:
         - 0: Overwrite existing group if present (default).
@@ -398,8 +397,6 @@ def store_processed_gb_file(
         If an unrecognized write_mode is provided.
     ValueError
         If an unexpected state is encountered when writing the HDF5 file.
-    AssertionError
-        If file integrity checks fail (e.g., mismatched SHA256 checksums).
     TypeError
         If the HDF5 file structure does not match the expected format.
     """

--- a/GalacticStochastic/inclusion_state_manager.py
+++ b/GalacticStochastic/inclusion_state_manager.py
@@ -252,13 +252,8 @@ class BinaryInclusionState(StateManager):
             Object tracking the current state of the iterative fit.
         nt_lim_waveform : PixelGenericRange
             Range of time-frequency pixels for waveform generation.
-        snrs_tot_in : NDArray[np.floating], optional
+        snrs_tot_in : NDArray[np.floating] | None, optional
             Array of precomputed total SNRs for each binary. If provided, used to filter faint binaries.
-
-        Raises
-        ------
-        AssertionError
-            If input arrays have inconsistent shapes or required conditions are not met.
         """
         self._wc: WDMWaveletConstants = wc
         self._ic: IterationConfig = ic

--- a/GalacticStochastic/iteration_config.py
+++ b/GalacticStochastic/iteration_config.py
@@ -43,7 +43,7 @@ def get_iteration_config(config: dict[str, Any]) -> IterationConfig:
 
     Parameters
     ----------
-    config : dict of str to Any
+    config : dict[str, Any]
         Configuration dictionary containing the 'iterative_fit_constants' section
         with all required keys and values for the iterative fit.
 
@@ -53,11 +53,7 @@ def get_iteration_config(config: dict[str, Any]) -> IterationConfig:
         Immutable named tuple containing all parameters and derived arrays for
         the iterative fitting process.
 
-    Raises
-    ------
-    AssertionError
-        If any required parameter is missing or has an invalid value.
-    """
+"""
     config_ic: dict[str, int | float | str] = config['iterative_fit_constants']
     # maximum number of iterations to allow
     max_iterations = int(config_ic['max_iterations'])

--- a/GalacticStochastic/iteration_config.py
+++ b/GalacticStochastic/iteration_config.py
@@ -53,7 +53,7 @@ def get_iteration_config(config: dict[str, Any]) -> IterationConfig:
         Immutable named tuple containing all parameters and derived arrays for
         the iterative fitting process.
 
-"""
+    """
     config_ic: dict[str, int | float | str] = config['iterative_fit_constants']
     # maximum number of iterations to allow
     max_iterations = int(config_ic['max_iterations'])

--- a/GalacticStochastic/iterative_fit.py
+++ b/GalacticStochastic/iterative_fit.py
@@ -48,11 +48,11 @@ def fetch_or_run_iterative_loop(
 
     Parameters
     ----------
-    config : dict of str to Any
+    config : dict[str, Any]
         Configuration dictionary containing file paths and fit settings.
     cyclo_mode : int | str
         Cyclostationary mode key for the fit.
-    nt_range_snr : tuple of int
+    nt_range_snr : tuple[int, int]
         Time-frequency pixel range as (min, max) indices. Defaults to (0, -1) for full range.
     fetch_mode : int | str
         Mode for fetching or running the fit:
@@ -67,13 +67,13 @@ def fetch_or_run_iterative_loop(
         0 or 'no_store': do not store;
         1 or 'store_if_new': store results unless they are fetched (default).
         2 or 'store_always': store results even they were fetched
-    wc_in : WDMWaveletConstants, optional
+    wc_in : WDMWaveletConstants | None, optional
         Optional override for wavelet constants.
-    lc_in : LISAConstants, optional
+    lc_in : LISAConstants | None, optional
         Optional override for LISA instrument constants.
-    ic_in : IterationConfig, optional
+    ic_in : IterationConfig | None, optional
         Optional override for iteration configuration.
-    instrument_random_seed_in : int, optional
+    instrument_random_seed_in : int | None, optional
         Optional override for instrument random seed.
     preprocess_mode : int | str
         Preprocessing mode:
@@ -81,6 +81,10 @@ def fetch_or_run_iterative_loop(
         1 or 'initial': do first step of pre-processing
         2 or 'repeat_initial': re-process an existing pre-processing result
         Default is 0.
+    params_gb_in : NDArray[np.floating] | None, optional
+        Optional override for the galactic binary parameter array. If None, loaded from file.
+    custom_params : int
+        If -1, set automatically based on whether params_gb_in is provided (default -1).
 
     Returns
     -------
@@ -95,6 +99,8 @@ def fetch_or_run_iterative_loop(
         If required files or entries are missing and fetch_mode is set to abort.
     NotImplementedError
         If an unsupported preprocess_mode is specified.
+    TypeError
+        If fetch_mode, output_mode, cyclo_mode, or preprocess_mode is not int or str.
     """
     # input validations
     assert output_mode in (0, 1, 2, 'no_store', 'store_if_new', 'store_always'), 'Unrecognized option for output mode'

--- a/GalacticStochastic/noise_manager.py
+++ b/GalacticStochastic/noise_manager.py
@@ -256,6 +256,8 @@ class NoiseModelManager(StateManager):
             If the method is not implemented in a subclass.
         TypeError
             If the format is not as expected.
+        ValueError
+            If an unrecognized cyclo_mode is encountered.
         """
         if group_mode == 0:
             hf_noise = hf_in['noise_model']

--- a/LisaWaveformTools/algebra_tools.py
+++ b/LisaWaveformTools/algebra_tools.py
@@ -15,13 +15,17 @@ def gradient_uniform_inplace(ys: NDArray[np.floating], result: NDArray[np.floati
 
     Parameters
     ----------
-    ys : numpy.ndarray
+    ys : NDArray[np.floating]
         Input 2D array of shape (nc_loc, n_ys) containing y-values to differentiate.
         Array is assumed to be on a uniform grid along the second axis
-    result : numpy.ndarray
+    result : NDArray[np.floating]
         Output array of same shape as ys where gradient values will be stored
     dx : float
         Step size between x-values (uniform grid spacing)
+    nx_min : int
+        Start index along second axis (inclusive, default 0).
+    nx_max : int
+        End index along second axis (exclusive, default -1 means n_ys).
 
     Notes
     -----
@@ -71,13 +75,13 @@ def stabilized_gradient_uniform_inplace(
 
     Parameters
     ----------
-    x : numpy.ndarray
+    x : NDArray[np.floating]
         1D array of reference values of length n_t
-    dxdt : numpy.ndarray
+    dxdt : NDArray[np.floating]
         1D array containing the known derivative of x, must be same shape as x
-    y : numpy.ndarray
+    y : NDArray[np.floating]
         2D array of shape (nc_channel, n_t) containing the perturbed curves
-    dydt : numpy.ndarray
+    dydt : NDArray[np.floating]
         2D array of same shape as y where the computed gradients will be stored
     dt : float
         Time step size for gradient calculation

--- a/LisaWaveformTools/instrument_noise.py
+++ b/LisaWaveformTools/instrument_noise.py
@@ -190,6 +190,10 @@ def instrument_noise_AET_wdm_m(lc: LISAConstants, wc: WDMWaveletConstants, tdi_m
         constants for LISA constellation specified in lisa_config.py
     wc : WDMWaveletConstants
         constants for WDM wavelet basis also from wdm_config.py
+    tdi_mode : str
+        TDI channel combination to use (default 'aet_equal').
+    diagonal_mode : int
+        If 0, return the full noise curve (default 0).
 
     Returns
     -------
@@ -197,7 +201,7 @@ def instrument_noise_AET_wdm_m(lc: LISAConstants, wc: WDMWaveletConstants, tdi_m
         array of the instrument noise curve for each TDI channel
         array shape is (freq. layers x number of TDI channels)
 
-    """
+"""
     # TODO why no plus 1?
     ls: NDArray[np.integer] = np.arange(-wc.Nt // 2, wc.Nt // 2)
     fs: NDArray[np.floating] = ls / wc.Tobs

--- a/LisaWaveformTools/instrument_noise.py
+++ b/LisaWaveformTools/instrument_noise.py
@@ -193,15 +193,16 @@ def instrument_noise_AET_wdm_m(lc: LISAConstants, wc: WDMWaveletConstants, tdi_m
     tdi_mode : str
         TDI channel combination to use (default 'aet_equal').
     diagonal_mode : int
-        If 0, return the full noise curve (default 0).
+        If 0, return the diagonal noise power spectrum, shape (Nf, 3) (default).
+        If 1, return the full noise covariance matrix, shape (Nf, 3, 3).
 
     Returns
     -------
-    S_stat_m : numpy.ndarray (Nf x 3)
-        array of the instrument noise curve for each TDI channel
-        array shape is (freq. layers x number of TDI channels)
+    S_stat_m : NDArray[np.floating]
+        If diagonal_mode=0: array of shape (Nf, 3) with the per-channel noise power spectrum.
+        If diagonal_mode=1: array of shape (Nf, 3, 3) with the full noise covariance matrix.
 
-"""
+    """
     # TODO why no plus 1?
     ls: NDArray[np.integer] = np.arange(-wc.Nt // 2, wc.Nt // 2)
     fs: NDArray[np.floating] = ls / wc.Tobs

--- a/LisaWaveformTools/linear_frequency_source.py
+++ b/LisaWaveformTools/linear_frequency_source.py
@@ -113,8 +113,10 @@ def linear_frequency_intrinsic(
         The intrinsic_waveform object to be updated in place with the time domain intrinsic_waveform.
     intrinsic_params : LinearFrequencyIntrinsicParams
         Dictionary or namespace containing intrinsic parameters of the source.
-    t_in : np.ndarray
+    t_in : NDArray[np.float64]
         Array of arrival times (or evaluation times) for the signal.
+    t_phase_ref : np.float64
+        Reference time subtracted from t_in before computing the phase (default 0.0).
 
     Returns
     -------

--- a/LisaWaveformTools/linear_frequency_source_freq.py
+++ b/LisaWaveformTools/linear_frequency_source_freq.py
@@ -25,6 +25,9 @@ def linear_frequency_intrinsic_freq(
 
     pt = params[6] + 2.0 * np.pi * (params[8] - ts) * fs + np.pi * params[7] * params[0] * xs**2 + np.pi / 4.
     pf = params[6] + 2.0 * np.pi * params[8] * fs + np.pi * params[0] * params[7] * xs**2
+    Note that t_in is not the same as the time coordinate in the input intrinsic_waveform object;
+    it may be a different time coordinate, due to the need to convert from the solar system barycenter
+    frame to the constellation guiding center frame (or the frames of the individual spacecraft).
 
     Parameters
     ----------

--- a/LisaWaveformTools/linear_frequency_source_freq.py
+++ b/LisaWaveformTools/linear_frequency_source_freq.py
@@ -31,12 +31,12 @@ def linear_frequency_intrinsic_freq(
 
     Parameters
     ----------
-    waveform : StationaryWaveformTime
-        The intrinsic_waveform object to be updated in place with the time domain intrinsic_waveform.
+    waveform : StationaryWaveformFreq
+        The intrinsic_waveform object to be updated in place with the frequency domain intrinsic_waveform.
     intrinsic_params : LinearFrequencyIntrinsicParams
         Dictionary or namespace containing intrinsic parameters of the source.
-    t_in : np.ndarray
-        Array of arrival times (or evaluation times) for the signal.
+    f_in : NDArray[np.floating]
+        Array of frequencies (Hz) at which to evaluate the signal.
 
     Returns
     -------

--- a/LisaWaveformTools/linear_frequency_source_freq.py
+++ b/LisaWaveformTools/linear_frequency_source_freq.py
@@ -25,9 +25,6 @@ def linear_frequency_intrinsic_freq(
 
     pt = params[6] + 2.0 * np.pi * (params[8] - ts) * fs + np.pi * params[7] * params[0] * xs**2 + np.pi / 4.
     pf = params[6] + 2.0 * np.pi * params[8] * fs + np.pi * params[0] * params[7] * xs**2
-    Note that t_in is not the same as the time coordinate in the input intrinsic_waveform object;
-    it may be a different time coordinate, due to the need to convert from the solar system barycenter
-    frame to the constellation guiding center frame (or the frames of the individual spacecraft).
 
     Parameters
     ----------

--- a/LisaWaveformTools/noise_model.py
+++ b/LisaWaveformTools/noise_model.py
@@ -71,8 +71,10 @@ def get_sparse_snr_helper(
         the range of time pixels to allow
     wc : WDMWaveletConstants
         constants for WDM wavelet basis also from wdm_config.py
-    inv_chol_S :
-
+    inv_chol_S : NDArray[np.floating]
+        inverse square root of the noise covariance, shape (Nt, Nf, nc_noise)
+    nc_snr : int
+        number of TDI channels to calculate S/N for
 
     Returns
     -------
@@ -372,7 +374,12 @@ class DenseNoiseModel(ABC):
             Freq pixels, Number of TDI channels.
             Pixel dimensions specified by wdm_config.py
 
-        """
+        Raises
+        ------
+        ValueError
+            If white_mode is not 0 or 1, or seed_override is less than -2.
+
+"""
         if white_mode not in (0, 1):
             msg = 'Unrecognized option for white_mode'
             raise ValueError(msg)
@@ -446,7 +453,7 @@ class DiagonalNonstationaryDenseNoiseModel(DenseNoiseModel):
 
         Parameters
         ----------
-        S : numpy.ndarray
+        S : NDArray[np.floating]
             array of dense noise curves for each TDI channel
             shape: (Nt x Nf x nc_noise)=(freq layers x number of TDI channels)
         wc : WDMWaveletConstants
@@ -454,19 +461,17 @@ class DiagonalNonstationaryDenseNoiseModel(DenseNoiseModel):
         prune : int
             if prune=1, cut the 1st and last values,
             which may not be calculated correctly
+        nc_snr : int
+            number of TDI channels to calculate S/N for
+            (should be less than or equal to the number of TDI channels in S)
         seed : int
             non-negative integer random seed for the noise generator;
             if set, generate_dense_noise will always produce the same result
             if -1, generate_dense_noise will get a new seed every time
-        nc_snr : int
-            number of TDI channels to calculate S/N for
-            (should be less than or equal to the number of TDI channels in S)
+        storage_mode : int
+            Storage mode for the noise model (default 0).
 
-        Returns
-        -------
-        DiagonalNonstationaryDenseNoiseModel : class
-
-        """
+"""
         assert len(S.shape) == 3
         assert S.shape[0] == wc.Nt
         assert S.shape[1] == wc.Nf
@@ -515,7 +520,7 @@ class DiagonalStationaryDenseNoiseModel(DenseNoiseModel):
 
         Parameters
         ----------
-        S_stat_m : numpy.ndarray
+        S_stat_m : NDArray[np.floating]
             array of stationary noise curves for each TDI channel,
             such as instrument noise output from instrument_noise_AET_wdm_m
             shape: (Nf x nc_noise) freq layers x number of TDI channels
@@ -533,12 +538,10 @@ class DiagonalStationaryDenseNoiseModel(DenseNoiseModel):
             non-negative integer random seed for the noise generator;
             if set, generate_dense_noise will always produce the same result
             if -1, generate_dense_noise will get a new seed every time
+        storage_mode : int
+            Storage mode for the noise model (default 0).
 
-        Returns
-        -------
-        DiagonalStationaryDenseNoiseModel : class
-
-        """
+"""
         assert len(S_stat_m.shape) == 2
         assert S_stat_m.shape[0] == wc.Nf
         super().__init__(

--- a/LisaWaveformTools/noise_model.py
+++ b/LisaWaveformTools/noise_model.py
@@ -81,7 +81,7 @@ def get_sparse_snr_helper(
     snr : numpy.ndarray
         an array of shape (nc_snr) which is the S/N for each TDI channel represented.
 
-"""
+    """
     snr2s = np.zeros(nc_snr)
     for itrc in range(nc_snr):
         n_pixel_loc: int = int(wavelet_waveform.n_set[itrc])
@@ -471,7 +471,7 @@ class DiagonalNonstationaryDenseNoiseModel(DenseNoiseModel):
         storage_mode : int
             Storage mode for the noise model (default 0).
 
-"""
+        """
         assert len(S.shape) == 3
         assert S.shape[0] == wc.Nt
         assert S.shape[1] == wc.Nf
@@ -541,7 +541,7 @@ class DiagonalStationaryDenseNoiseModel(DenseNoiseModel):
         storage_mode : int
             Storage mode for the noise model (default 0).
 
-"""
+        """
         assert len(S_stat_m.shape) == 2
         assert S_stat_m.shape[0] == wc.Nf
         super().__init__(

--- a/LisaWaveformTools/noise_model.py
+++ b/LisaWaveformTools/noise_model.py
@@ -79,9 +79,9 @@ def get_sparse_snr_helper(
     Returns
     -------
     snr : numpy.ndarray
-        an array of shape (nc_noise) which is the S/N for each TDI channel represented.
+        an array of shape (nc_snr) which is the S/N for each TDI channel represented.
 
-    """
+"""
     snr2s = np.zeros(nc_snr)
     for itrc in range(nc_snr):
         n_pixel_loc: int = int(wavelet_waveform.n_set[itrc])
@@ -379,7 +379,7 @@ class DenseNoiseModel(ABC):
         ValueError
             If white_mode is not 0 or 1, or seed_override is less than -2.
 
-"""
+        """
         if white_mode not in (0, 1):
             msg = 'Unrecognized option for white_mode'
             raise ValueError(msg)

--- a/LisaWaveformTools/ra_waveform_time.py
+++ b/LisaWaveformTools/ra_waveform_time.py
@@ -88,11 +88,15 @@ def spacecraft_channel_deriv_helper(spacecraft_channels: AntennaResponseChannels
 
     Parameters
     ----------
-    spacecraft_channels: SpacecraftChannels
+    spacecraft_channels: AntennaResponseChannels
         Object containing the spacecraft channels with RR, II, dRR, and dII attributes,
         with RR and II already computed.
-    nx_lim: PixelGenericRange
-        Range of indices to compute the derivatives over and time spacing of uniform samples
+    dx : float
+        Uniform time spacing between samples.
+    nx_min : int
+        Start index along the time axis (inclusive, default 0).
+    nx_max : int
+        End index along the time axis (exclusive, default -1 means full array).
 
     Returns
     -------
@@ -188,20 +192,22 @@ def amp_phase_loop_helper(
 
     Parameters
     ----------
-    F: NDArray[float]
+    F : NDArray[np.floating]
         Array of frequencies corresponding to the waveform samples
-    T: NDArray[float]
+    T : NDArray[np.floating]
         Array of times corresponding to the waveform samples
-    spacecraft_channels : SpacecraftChannels
-        Object containing the real (RR) and imaginary (II) components of the spacecraft
-        response, along with their derivatives (dRR, dII)
+    waveform : StationaryWaveformGeneric
+        Input intrinsic_waveform object containing the original phase (PT) and amplitude (AT) data
     AET_waveform : StationaryWaveformGeneric
         Target intrinsic_waveform object where the modified TDI amplitude and phase will be stored.
         Modified in-place with computed values
-    waveform : StationaryWaveformGeneric
-        Input intrinsic_waveform object containing the original phase (PT) and amplitude (AT) data
+    spacecraft_channels : AntennaResponseChannels
+        Object containing the real (RR) and imaginary (II) components of the spacecraft
+        response, along with their derivatives (dRR, dII)
     lc : LISAConstants
         LISA constellation constants containing the strain frequency (fstr)
+    nx_lim : PixelGenericRange
+        Range of time-sample indices to process.
 
     Notes
     -----
@@ -326,7 +332,7 @@ def get_time_tdi_amp_phase_helper(
 
     Parameters
     ----------
-    spacecraft_channels : SpacecraftChannels
+    spacecraft_channels : AntennaResponseChannels
         Object containing the real (RR) and imaginary (II) components of the spacecraft
         response, along with their derivatives (dRR, dII)
     AET_waveform : StationaryWaveformTime
@@ -416,7 +422,7 @@ def get_time_tdi_amp_phase(
 
     Parameters
     ----------
-    spacecraft_channels : SpacecraftChannels
+    spacecraft_channels : AntennaResponseChannels
         Object containing the real (RR) and imaginary (II) components of the spacecraft
         response, along with their derivatives (dRR, dII)
     AET_waveform : StationaryWaveformTime
@@ -454,6 +460,11 @@ def get_time_tdi_amp_phase(
     -------
     None
         Results are stored in-place in tdi_waveform
+
+    Raises
+    ------
+    NotImplementedError
+        If phase_wrap_mode is not 0 or 1.
 
     """
     # get and store dRR and dII in the object

--- a/LisaWaveformTools/stationary_source_waveform.py
+++ b/LisaWaveformTools/stationary_source_waveform.py
@@ -85,6 +85,12 @@ class StationarySourceWaveform(Generic[StationaryWaveformType, IntrinsicParamsTy
         ----------
         params : SourceParams
             Model-specific parameters (intrinsic and extrinsic) for the source.
+        intrinsic_waveform : StationaryWaveformType
+            Object for storing the intrinsic waveform.
+        tdi_waveform : StationaryWaveformType
+            Object for storing the TDI response waveform.
+        response_mode : int
+            Response mode for the waveform (default 0).
         """
         self._consistent: bool = False
         self._consistent_intrinsic: bool = False
@@ -249,6 +255,11 @@ class StationarySourceWaveform(Generic[StationaryWaveformType, IntrinsicParamsTy
         -------
         tdi_waveform: StationaryWaveformType
             The TDI intrinsic_waveform channels computed from the source parameters.
+
+        Raises
+        ------
+        ValueError
+            If the source parameters have not been updated yet.
         """
         if not self.consistent_extrinsic:
             msg = 'Source parameters have not been updated yet.'
@@ -264,6 +275,11 @@ class StationarySourceWaveform(Generic[StationaryWaveformType, IntrinsicParamsTy
         -------
         intrinsic_waveform: StationaryWaveformType
             The intrinsic intrinsic_waveform computed for the source parameters.
+
+        Raises
+        ------
+        ValueError
+            If the source parameters have not been updated yet.
         """
         if not self.consistent_instrinsic:
             msg = 'Source parameters have not been updated yet.'

--- a/WaveletWaveforms/taylor_time_coefficients.py
+++ b/WaveletWaveforms/taylor_time_coefficients.py
@@ -93,9 +93,10 @@ def wavelet(wc: WDMWaveletConstants, m: int | float, nrm: float, *, n_in: int = 
     m : int | float
         The index of the frequency bin around which to center the wavelet.
         Although it has units of an index, it is actually a frequency and so need not necessarily be an integer
-
     nrm : float
         Normalization factor to scale the resulting wavelet.
+    n_in : int
+        Number of time samples to use; if -1 (default), uses wc.K.
     Returns
     -------
     wave : np.ndarray
@@ -153,7 +154,7 @@ def get_taylor_table_time_helper(
 
     Parameters
     ----------
-    wavelet_norm : np.ndarray
+    wavelet_norm : NDArray[np.floating]
         The normalized reference wavelet sampled on the relevant time grid.
     wc : WDMWaveletConstants
         Wavelet decomposition configuration, specifying time step,
@@ -632,6 +633,10 @@ def get_taylor_table_time(
     filename_base : str, optional
         Base file name for the cache file (before appending grid parameters).
         (default is 'taylor_time_table_')
+    grid_check_mode : int
+        Controls the grid precision check: 0 skips it, 1 runs it (default 1).
+    assert_mode : int
+        If 1, raise ValueError when grid precision check fails; otherwise warn (default 1).
 
     Returns
     -------
@@ -644,6 +649,8 @@ def get_taylor_table_time(
     ValueError
         If the requested interpolation grid parameters exceed the valid range
         for the Taylor approximation, or if grid settings are inconsistent.
+    NotImplementedError
+        If cache_mode or output_mode is not a recognized option.
 
     Notes
     -----

--- a/WaveletWaveforms/taylor_time_wavelet_funcs.py
+++ b/WaveletWaveforms/taylor_time_wavelet_funcs.py
@@ -66,8 +66,8 @@ def wavemaket(
         amplitude is zero or very small, and thus dropping them is acceptable for some applications.
         For snr calculations, plotting, or computing coadded galactic backgrounds, force_nulls=1 has little benefit.
         However, for likelihood calculations, force_nulls=1 appropriately penalizes data that has power in nulls.
-        force_nulls=2 is reserved for calculating wavelet coefficients outside the precomputed table directly,
-        but currently returns a NotImplementedError
+        force_nulls=2 computes wavelet coefficients outside the precomputed table directly
+        rather than approximating them as zero; acceptable when such pixels are rare.
     amplitude_order : int
         Order of amplitude correction to apply: 0 for none, 1 for first-order (default 0).
 
@@ -79,7 +79,7 @@ def wavemaket(
     Raises
     ------
     NotImplementedError
-        If force_nulls=2 is requested (not yet implemented).
+        If force_nulls is not 0, 1, or 2.
 
     See Also
     --------

--- a/WaveletWaveforms/taylor_time_wavelet_funcs.py
+++ b/WaveletWaveforms/taylor_time_wavelet_funcs.py
@@ -68,12 +68,18 @@ def wavemaket(
         However, for likelihood calculations, force_nulls=1 appropriately penalizes data that has power in nulls.
         force_nulls=2 is reserved for calculating wavelet coefficients outside the precomputed table directly,
         but currently returns a NotImplementedError
-
+    amplitude_order : int
+        Order of amplitude correction to apply: 0 for none, 1 for first-order (default 0).
 
     Returns
     -------
     None
         This function modifies `wavelet_waveform` in place and does not return a value.
+
+    Raises
+    ------
+    NotImplementedError
+        If force_nulls=2 is requested (not yet implemented).
 
     See Also
     --------
@@ -330,6 +336,8 @@ def wavemaket_direct(
         - `df_bw`: Spacing of frequency layers (bandwidth) in frequency direction.
     taylor_table : WaveletTaylorTimeCoeffs
         Taylor expansion coefficients and normalization factors required for direct evaluation.
+    amplitude_order : int
+        Order of amplitude correction to apply: 0 for none, 1 for first-order (default 0).
 
     Returns
     -------


### PR DESCRIPTION
## Summary

- Resolves all 75 pydoclint findings across 18 files to achieve `🎉 No violations 🎉`
- **Docstrings only** — no logic, signatures, type annotations, or non-docstring comments were changed
- All docstrings remain numpy style and pass enabled pydocstyle rules

## Patterns fixed

| Violation | Fix applied |
|-----------|-------------|
| DOC501/502 — `AssertionError`/`UserWarning` in Raises | Removed: `assert` statements and `warn()` calls are not explicit raises |
| DOC105 — union type syntax | Updated `float or NDArray` → `NDArray \| float`, `dict of str to Any` → `dict[str, Any]`, `tuple of int` → `tuple[int, int]` |
| DOC101/103 — missing or wrong parameter names | Added missing params; corrected names to match signatures |
| DOC104 — wrong parameter order | Reordered docstring params to match function signature exactly |
| DOC302/303 — `__init__` with Returns section | Removed Returns sections from `__init__` docstrings |

## Files changed (18)

`GalacticStochastic/`: background_decomposition, config_helper, cosmic_data_helpers, galactic_fit_helpers, global_file_index, inclusion_state_manager, iteration_config, iterative_fit, noise_manager

`LisaWaveformTools/`: algebra_tools, instrument_noise, linear_frequency_source, linear_frequency_source_freq, noise_model, ra_waveform_time, stationary_source_waveform

`WaveletWaveforms/`: taylor_time_coefficients, taylor_time_wavelet_funcs

## Human review item

One material discrepancy was found and corrected in `linear_frequency_source_freq.py::linear_frequency_intrinsic_freq` — the docstring was a stale copy-paste from the time-domain version, with `t_in : np.ndarray` / `StationaryWaveformTime` instead of `f_in : NDArray[np.floating]` / `StationaryWaveformFreq`. The docstring was updated to match the code. **Please verify the function implementation itself is correct** and was not accidentally cloned from the time-domain version.

## Test plan

- [x] `mamba run -n gstoch-dev pydoclint --config=pyproject.toml GalacticStochastic/ LisaWaveformTools/ WaveletWaveforms/` → `🎉 No violations 🎉`
- [x] Pre-existing test failures (`test_time_tdi_ampphase.py`, `test_wavemaket.py`) confirmed to exist on `main` before this branch — not introduced by these changes
- [ ] Full test suite pass (pending data files needed by skipped tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)