### PR TITLE
tests: fix pyright reportPrivateImportUsage from numba 0.66.0

### DIFF
--- a/tests/test_algebra_tools.py
+++ b/tests/test_algebra_tools.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numba
 import numpy as np
 import pytest
+from numba.core.errors import TypingError
 from numpy.testing import assert_allclose, assert_array_equal
 
 from LisaWaveformTools.algebra_tools import gradient_uniform_inplace, stabilized_gradient_uniform_inplace
@@ -74,7 +74,7 @@ def test_gradient_uniform_inplace_raise_bad_shape7() -> None:
     DT = 0.1
     x = np.zeros(100)
     y = np.zeros(100)
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         gradient_uniform_inplace(x, y, DT)
 
 
@@ -83,7 +83,7 @@ def test_gradient_uniform_inplace_raise_bad_shape8() -> None:
     DT = 0.1
     x = np.zeros((3, 100, 1))
     y = np.zeros((3, 100, 1))
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         gradient_uniform_inplace(x, y, DT)
 
 
@@ -92,7 +92,7 @@ def test_gradient_uniform_inplace_raise_bad_shape9() -> None:
     DT = 0.1
     x = np.zeros((3, 100, 1))
     y = np.zeros((3, 100))
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         gradient_uniform_inplace(x, y, DT)
 
 
@@ -114,7 +114,7 @@ def test_stabilized_gradient_uniform_inplace_raise_bad_shape2() -> None:
     dxdt = np.zeros(100)
     y = np.zeros((3, 100))
     dydt = np.zeros((3, 100))
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         stabilized_gradient_uniform_inplace(x, dxdt, y, dydt, DT)
 
 
@@ -202,7 +202,7 @@ def test_stabilized_gradient_uniform_inplace_raise_bad_shape10() -> None:
     dxdt = np.zeros((100, 1))
     y = np.zeros((3, 100))
     dydt = np.zeros((3, 100))
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         stabilized_gradient_uniform_inplace(x, dxdt, y, dydt, DT)
 
 
@@ -213,7 +213,7 @@ def test_stabilized_gradient_uniform_inplace_raise_bad_shape11() -> None:
     dxdt = np.zeros(100)
     y = np.zeros((3, 100, 1))
     dydt = np.zeros((3, 100))
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         stabilized_gradient_uniform_inplace(x, dxdt, y, dydt, DT)
 
 
@@ -224,7 +224,7 @@ def test_stabilized_gradient_uniform_inplace_raise_bad_shape12() -> None:
     dxdt = np.zeros(100)
     y = np.zeros((3, 100, 1))
     dydt = np.zeros((3, 100, 1))
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         stabilized_gradient_uniform_inplace(x, dxdt, y, dydt, DT)
 
 
@@ -235,7 +235,7 @@ def test_stabilized_gradient_uniform_inplace_raise_bad_shape13() -> None:
     dxdt = np.zeros(101)
     y = np.zeros((3, 100))
     dydt = np.zeros((3, 100))
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         stabilized_gradient_uniform_inplace(x, dxdt, y, dydt, DT)
 
 
@@ -246,7 +246,7 @@ def test_stabilized_gradient_uniform_inplace_raise_bad_shape14() -> None:
     dxdt = np.zeros(100)
     y = np.zeros(100)
     dydt = np.zeros(100)
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         stabilized_gradient_uniform_inplace(x, dxdt, y, dydt, DT)
 
 
@@ -257,7 +257,7 @@ def test_stabilized_gradient_uniform_inplace_raise_bad_shape15() -> None:
     dxdt = np.zeros((3, 100))
     y = np.zeros(100)
     dydt = np.zeros(100)
-    with pytest.raises((AssertionError, numba.errors.TypingError)):
+    with pytest.raises((AssertionError, TypingError)):
         stabilized_gradient_uniform_inplace(x, dxdt, y, dydt, DT)
 
 


### PR DESCRIPTION
## Problem

The **Type Check → pyright** CI job started failing with no code or CI changes. Bisecting the runs on the `codex/consolidator-compact-evidence` stack:

| Commit | Time (UTC) | numba resolved | pyright |
|--------|-----------|----------------|---------|
| 9f4c314 | 2026-07-01 21:38 | 0.65.1 | ✅ |
| *numba 0.66.0 released* | 2026-07-01 23:12 | — | — |
| 0585369 | 2026-07-02 04:09 | 0.66.0 | ❌ |

The pyright job installs typed extras **unpinned** (`uv pip install ".[dev,plots,cosmic]"`), so it resolves to the latest numba on every run. **numba 0.66.0** (published 2026-07-01T23:12 UTC) stopped re-exporting the `errors` submodule from the top-level `numba` namespace. pyright 1.1.410 then flags all 10 `numba.errors.TypingError` accesses in `tests/test_algebra_tools.py` as `reportPrivateImportUsage`.

## Fix

Import `TypingError` directly from its defining module, `numba.core.errors`, instead of reaching it through the `numba` namespace. This:

- resolves the `reportPrivateImportUsage` error regardless of numba version,
- works on the locally installed numba 0.65.1 as well as CI's 0.66.0 (verified `numba.errors is numba.core.errors`),
- introduces **no new numba version floor** — it's purely an import-site change, `pyproject.toml` untouched.

## Verification

- `ruff check` — passes
- `pytest tests/test_algebra_tools.py` — 24646 passed
- `pyright tests/test_algebra_tools.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)